### PR TITLE
Add /html endpoint to serve HTML files

### DIFF
--- a/server.js
+++ b/server.js
@@ -44,6 +44,12 @@ app.get("/files/:name", function (req, res) {
   res.download(path.join(__dirname, `/uploads/${fileName}`));
 });
 
+app.get("/html/:name", function (req, res) {
+  let fileName = req.params.name;
+
+  res.sendFile(path.join(__dirname, `/uploads/${fileName}`));
+});
+
 app.post("/upload", upload.single("file"), (req, res) => {
   return res.status(200).send(req.file);
 });


### PR DESCRIPTION
Add a new endpoint `/html/:name` to serve HTML files from the `uploads` directory.

* Use `res.sendFile` to serve the HTML file.
* Construct the file path using `path.join`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/gquarles/quickhost?shareId=54517d0a-3e8d-4811-ad14-982cf16e046d).